### PR TITLE
Change font from 'Oswald' to 'Anton'

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Baloo+Da+2:wght@800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Anton&display=swap" rel="stylesheet">
 
   <title>Batname - Generate Batman Logos</title>
 

--- a/src/lib/BatCanvas.svelte
+++ b/src/lib/BatCanvas.svelte
@@ -48,7 +48,7 @@
 
     context.font = batData.isBengali
       ? "800 25px 'Baloo Da 2'"
-      : "700 25px 'Oswald'";
+      : "25px 'Anton'";
 
     const measurement = context.measureText(batData.name);
     const textScale = Math.min(

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,7 +4,7 @@ const config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Oswald', 'sans-serif'],
+        sans: ['Anton', 'sans-serif'],
         bengali: ["'Baloo Da 2'"]
       }
     },


### PR DESCRIPTION
This font is more like to the font of 'The Batman 2022' logo.

The logo of 'The Batman 2022':
![image](https://user-images.githubusercontent.com/29206777/155893592-bd1be1cf-91cb-4423-bfc8-83edb4578b11.png)

Generated images for **BATMAN** text with different fonts:

| `Oswald` | `Anton` |
|--------|--------|
|   ![image](https://user-images.githubusercontent.com/29206777/155893802-4894ec47-847c-449a-9d5a-004511e6e838.png)    |    ![image](https://user-images.githubusercontent.com/29206777/155893812-b7e41f38-973c-4170-9299-d9bf3c5ece11.png)    |
|    The **old font**    |    The **new font**    |

